### PR TITLE
Camera: Lerp Speed Property

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,6 +17,9 @@
 # Dependency directories (remove the comment below to include it)
 # vendor/
 
+# IDE/Editor directories
+.idea/*
+
 # Go workspace file
 go.work
 examples/.DS_Store

--- a/camera.go
+++ b/camera.go
@@ -16,7 +16,8 @@ type Camera struct {
 	ZoomFactor float64
 
 	// Interpolate camera movement
-	Lerp bool
+	Lerp      bool
+	LerpSpeed float64
 
 	// Camera shake options
 	ShakeOptions CameraShakeOptions
@@ -34,6 +35,7 @@ func NewCamera(lookAtX, lookAtY, w, h float64) *Camera {
 	c := &Camera{
 		ZoomFactor:   0,
 		Lerp:         false,
+		LerpSpeed:    0.1,
 		ShakeOptions: DefaultCameraShakeOptions(),
 		// private
 		w:            w,
@@ -59,7 +61,7 @@ func NewCamera(lookAtX, lookAtY, w, h float64) *Camera {
 func (cam *Camera) LookAt(targetX, targetY float64) {
 	target := vec2{targetX, targetY}
 	if cam.Lerp {
-		cam.tempTarget = cam.tempTarget.Lerp(target, 0.1)
+		cam.tempTarget = cam.tempTarget.Lerp(target, cam.LerpSpeed)
 		cam.topLeft = cam.tempTarget
 	} else {
 		cam.topLeft = target


### PR DESCRIPTION
The default addition of a lerp to the camera is great, but I find I want to control the lerp's speed sometimes. This change should leave functionality unchanged with no code change for other users, but now allow those users to customize the lerp speed.